### PR TITLE
Move SCCS location to new repo

### DIFF
--- a/chapter-6/chapter-6-quarkus-rest-cloud-config/README.md
+++ b/chapter-6/chapter-6-quarkus-rest-cloud-config/README.md
@@ -64,9 +64,9 @@ For local tests, you can launch the SCC server using docker
 
 ```bash
 docker run -it -p 8888:8888 \
-      -e SPRING_CLOUD_CONFIG_SERVER_GIT_URI=https://github.com/ch007m/config-repo \
+      -e SPRING_CLOUD_CONFIG_SERVER_GIT_URI=https://github.com/quarkus-for-spring-developers/sccs-config-repo \
       -e SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT-LABEL=main \
-      -e SPRING_CLOUD_CONFIG_SERVER_GIT_SEARCHPATHS=chapter-6 \
+      -e SPRING_CLOUD_CONFIG_SERVER_GIT_SEARCHPATHS={application} \
       hyness/spring-cloud-config-server
 ```
 

--- a/chapter-6/chapter-6-quarkus-rest-cloud-config/src/main/k8s/helm.yml
+++ b/chapter-6/chapter-6-quarkus-rest-cloud-config/src/main/k8s/helm.yml
@@ -11,9 +11,8 @@
 # helm delete spring-cloud-config-server -n config-storage
 #
 config:
-  # gitUri: https://github.com/quarkus-for-spring-developers/examples.git
-  gitUri: https://github.com/ch007m/config-repo.git
-  gitSearchpath: chapter-6
+  gitUri: https://github.com/quarkus-for-spring-developers/sccs-config-repo
+  gitSearchpath: {application}
 extraEnv:
   - name: SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT-LABEL
     value: main

--- a/chapter-6/greeting-application.properties
+++ b/chapter-6/greeting-application.properties
@@ -1,2 +1,0 @@
-greeting.message=Hello cloud config
-greeting.name=quarkus


### PR DESCRIPTION
Moving SCCS stuff to new repo.

@cmoulliard can you review? The repo is public for now & I was able to run 

```shell
docker run -it -p 8888:8888 \
      -e SPRING_CLOUD_CONFIG_SERVER_GIT_URI=https://github.com/quarkus-for-spring-developers/sccs-config-repo \
      -e SPRING_CLOUD_CONFIG_SERVER_GIT_DEFAULT-LABEL=main \
      -e SPRING_CLOUD_CONFIG_SERVER_GIT_SEARCHPATHS={application} \
      hyness/spring-cloud-config-server
```

And then running `http :8888/greeting-application-prod.properties` returns

```shell
HTTP/1.1 200 
Connection: keep-alive
Content-Length: 59
Content-Type: text/plain
Date: Fri, 25 Jun 2021 18:23:35 GMT
Keep-Alive: timeout=60

greeting.message: Hello cloud config
greeting.name: quarkus
```

Fixes #84 